### PR TITLE
Preserve admin user for replay

### DIFF
--- a/common/src/main/java/engineering/everest/lhotse/axon/common/domain/User.java
+++ b/common/src/main/java/engineering/everest/lhotse/axon/common/domain/User.java
@@ -11,12 +11,15 @@ import java.util.UUID;
 import static engineering.everest.lhotse.axon.common.domain.Role.ADMIN;
 import static engineering.everest.lhotse.axon.common.domain.Role.ORG_ADMIN;
 import static engineering.everest.lhotse.axon.common.domain.Role.ORG_USER;
+import static java.util.UUID.fromString;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @SuppressWarnings("PMD.ShortClassName")
 public class User implements Identifiable {
+
+    public static final UUID ADMIN_ID = fromString("00000000-0000-0000-0000-000000000000");
 
     private UUID id;
     private UUID organizationId;

--- a/launcher/src/main/java/engineering/everest/lhotse/AdminProvisionTask.java
+++ b/launcher/src/main/java/engineering/everest/lhotse/AdminProvisionTask.java
@@ -8,21 +8,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.Optional;
-import java.util.UUID;
+import javax.annotation.PostConstruct;
 
 import static engineering.everest.lhotse.axon.common.domain.Role.ADMIN;
-import static java.util.UUID.fromString;
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 
 @Component
 @Log4j2
 public class AdminProvisionTask implements ReplayCompletionAware {
 
-    private static final UUID ADMIN_ID = fromString("00000000-0000-0000-0000-000000000000");
     private static final String ADMIN_DISPLAY_NAME = "Admin";
 
     private final Clock clock;

--- a/launcher/src/test/java/engineering/everest/lhotse/AdminProvisionTaskTest.java
+++ b/launcher/src/test/java/engineering/everest/lhotse/AdminProvisionTaskTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static engineering.everest.lhotse.axon.common.domain.Role.ADMIN;
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.fromString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -27,7 +28,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(SpringExtension.class)
 class AdminProvisionTaskTest {
 
-    private static final UUID ADMIN_ID = fromString("00000000-0000-0000-0000-000000000000");
     private static final String ADMIN_DISPLAY_NAME = "Admin";
     private static final String ADMIN_USERNAME = "admin-username";
     private static final String ADMIN_PASSWORD = "admin-raw-password";

--- a/organizations/src/test/java/engineering/everest/lhotse/organizations/domain/OrganizationAggregateTest.java
+++ b/organizations/src/test/java/engineering/everest/lhotse/organizations/domain/OrganizationAggregateTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 import static engineering.everest.lhotse.axon.AxonTestUtils.mockCommandValidatingMessageHandlerInterceptor;
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.lenient;
@@ -35,7 +36,6 @@ import static org.mockito.Mockito.lenient;
 class OrganizationAggregateTest {
 
     private static final UUID ORGANIZATION_ID = randomUUID();
-    private static final UUID ADMIN_ID = randomUUID();
     private static final String ORGANIZATION_NAME = "organization-name";
     private static final String NO_CHANGE = null;
     private static final String MISSING_ARGUMENT = null;

--- a/organizations/src/test/java/engineering/everest/lhotse/organizations/eventhandlers/OrganizationsEventHandlerTest.java
+++ b/organizations/src/test/java/engineering/everest/lhotse/organizations/eventhandlers/OrganizationsEventHandlerTest.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -31,7 +32,6 @@ class OrganizationsEventHandlerTest {
 
     private static final Instant ORG_CREATION_TIME = Instant.ofEpochSecond(6800L);
     private static final UUID ORGANIZATION_ID = randomUUID();
-    private static final UUID ADMIN_ID = randomUUID();
     private static final String ORGANIZATION_NAME = "organization name";
     private static final String ORGANIZATION_STREET = "street";
     private static final String ORGANIZATION_CITY = "city";

--- a/organizations/src/test/java/engineering/everest/lhotse/organizations/services/DefaultOrganizationsServiceTest.java
+++ b/organizations/src/test/java/engineering/everest/lhotse/organizations/services/DefaultOrganizationsServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
 
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.randomUUID;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,7 +23,6 @@ class DefaultOrganizationsServiceTest {
 
     private static final UUID ORGANIZATION_ID = randomUUID();
     private static final UUID NETWORK_ID = randomUUID();
-    private static final UUID ADMIN_ID = randomUUID();
     private static final String ORGANIZATION_NAME = "organization-name";
     private static final String ORGANIZATION_STREET_1 = "street-1";
     private static final String ORGANIZATION_CITY_1 = "city-1";

--- a/users-api/src/test/java/engineering/everest/lhotse/users/UserTestHelper.java
+++ b/users-api/src/test/java/engineering/everest/lhotse/users/UserTestHelper.java
@@ -1,18 +1,14 @@
 package engineering.everest.lhotse.users;
 
-
 import engineering.everest.lhotse.axon.common.domain.Role;
 import engineering.everest.lhotse.axon.common.domain.User;
 
 import java.util.EnumSet;
-import java.util.UUID;
 
 import static engineering.everest.lhotse.axon.common.domain.Role.ADMIN;
-import static java.util.UUID.fromString;
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 
 public class UserTestHelper {
-
-    public static final UUID ADMIN_ID = fromString("00000000-0000-0000-0000-000000000000");
 
     public static final String ADMIN_USERNAME = "admin@umbrella.com";
     public static final String ADMIN_DISPLAY_NAME = "Admin";

--- a/users-persistence/src/main/java/engineering/everest/lhotse/users/persistence/UsersRepository.java
+++ b/users-persistence/src/main/java/engineering/everest/lhotse/users/persistence/UsersRepository.java
@@ -20,4 +20,6 @@ public interface UsersRepository extends JpaRepository<PersistableUser, UUID> {
     Optional<PersistableUser> findByUsernameIgnoreCase(String username);
 
     Optional<PersistableUser> findByEmailIgnoreCase(String email);
+
+    void deleteByIdNot(UUID organizationId);
 }

--- a/users/src/main/java/engineering/everest/lhotse/users/eventhandlers/UsersEventHandler.java
+++ b/users/src/main/java/engineering/everest/lhotse/users/eventhandlers/UsersEventHandler.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
+
 @Service
 @Log4j2
 public class UsersEventHandler implements ReplayCompletionAware {
@@ -28,7 +30,7 @@ public class UsersEventHandler implements ReplayCompletionAware {
     @ResetHandler
     public void prepareForReplay() {
         LOGGER.info("{} deleting projections", UsersEventHandler.class.getSimpleName());
-        usersRepository.deleteAll();
+        usersRepository.deleteByIdNot(ADMIN_ID);
     }
 
     @EventHandler

--- a/users/src/test/java/engineering/everest/lhotse/users/domain/UserAggregateTest.java
+++ b/users/src/test/java/engineering/everest/lhotse/users/domain/UserAggregateTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import javax.validation.ConstraintViolationException;
 
 import static engineering.everest.lhotse.axon.AxonTestUtils.mockCommandValidatingMessageHandlerInterceptor;
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doThrow;
@@ -31,7 +32,6 @@ import static org.mockito.Mockito.doThrow;
 class UserAggregateTest {
 
     private static final UUID ORGANIZATION_ID = randomUUID();
-    private static final UUID ADMIN_ID = randomUUID();
     private static final UUID USER_ID = randomUUID();
     private static final UUID PROFILE_PHOTO_FILE_ID = randomUUID();
     private static final String USERNAME = "user@email.com";

--- a/users/src/test/java/engineering/everest/lhotse/users/eventhandlers/UsersEventHandlerTest.java
+++ b/users/src/test/java/engineering/everest/lhotse/users/eventhandlers/UsersEventHandlerTest.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
@@ -26,7 +27,6 @@ class UsersEventHandlerTest {
     private static final UUID USER_ID = randomUUID();
     private static final UUID ORGANIZATION_ID = randomUUID();
     private static final UUID PROFILE_PHOTO_FILE_ID = randomUUID();
-    private static final UUID ADMIN_ID = randomUUID();
     private static final Instant CREATION_TIME = Instant.ofEpochSecond(9999999L);
     private static final String USER_DISPLAY_NAME = "user-display-name";
     private static final String USER_USERNAME = "user-email";
@@ -48,7 +48,7 @@ class UsersEventHandlerTest {
     void prepareForReplay_willDeleteAllProjections() {
         usersEventHandler.prepareForReplay();
 
-        verify(usersRepository).deleteAll();
+        verify(usersRepository).deleteByIdNot(ADMIN_ID);
     }
 
     @Test

--- a/users/src/test/java/engineering/everest/lhotse/users/services/DefaultUsersServiceTest.java
+++ b/users/src/test/java/engineering/everest/lhotse/users/services/DefaultUsersServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.UUID;
 
+import static engineering.everest.lhotse.axon.common.domain.User.ADMIN_ID;
 import static java.util.UUID.randomUUID;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,7 +24,6 @@ class DefaultUsersServiceTest {
 
     private static final UUID ORGANIZATION_ID = randomUUID();
     private static final UUID USER_ID = randomUUID();
-    private static final UUID ADMIN_ID = randomUUID();
     private static final UUID PROFILE_PHOTO_FILE_ID = randomUUID();
     private static final String NEW_USER_EMAIL = "new-user-email";
     private static final String NEW_USER_DISPLAY_NAME = "new-user-display-name";


### PR DESCRIPTION
When replay is underway, we need the admin user to check the replay status via API. This PR makes sure the admin user is not deleted when replay is triggered.
Also consolidate usage of ADMIN_ID