### PR TITLE
[Refactor] Use correct file id naming for photo actions

### DIFF
--- a/src/database-support/src/main/resources/database/lhotse.xml
+++ b/src/database-support/src/main/resources/database/lhotse.xml
@@ -147,7 +147,7 @@
                 <constraints primaryKey="true" primaryKeyName="PK_photos"/>
             </column>
             <column name="owneruserid" type="uuid"/>
-            <column name="backingfileid" type="uuid"/>
+            <column name="persistedfileid" type="uuid"/>
             <column name="filename" type="varchar(255)"/>
             <column name="uploadtimestamp" type="timestamp"/>
         </createTable>

--- a/src/photos-api/src/main/java/engineering/everest/lhotse/photos/Photo.java
+++ b/src/photos-api/src/main/java/engineering/everest/lhotse/photos/Photo.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public class Photo {
     private UUID id;
     private UUID owningUserId;
-    private UUID backingFileId;
+    private UUID persistedFileId;
     private String filename;
     private Instant uploadTimestamp;
 }

--- a/src/photos-api/src/main/java/engineering/everest/lhotse/photos/domain/commands/RegisterUploadedPhotoCommand.java
+++ b/src/photos-api/src/main/java/engineering/everest/lhotse/photos/domain/commands/RegisterUploadedPhotoCommand.java
@@ -19,11 +19,11 @@ public class RegisterUploadedPhotoCommand implements FileStatusValidatableComman
     @NotNull
     private UUID owningUserId;
     @NotNull
-    private UUID backingFileId;
+    private UUID persistedFileId;
     private String filename;
 
     @Override
     public Set<UUID> getFileIDs() {
-        return Set.of(backingFileId);
+        return Set.of(persistedFileId);
     }
 }

--- a/src/photos-api/src/main/java/engineering/everest/lhotse/photos/services/PhotosService.java
+++ b/src/photos-api/src/main/java/engineering/everest/lhotse/photos/services/PhotosService.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 
 public interface PhotosService {
 
-    UUID registerUploadedPhoto(UUID requestingUserId, UUID backingFileId, String filename);
+    UUID registerUploadedPhoto(UUID requestingUserId, UUID persistedFileId, String filename);
 }

--- a/src/photos-persistence/src/main/java/engineering/everest/lhotse/photos/persistence/PersistablePhoto.java
+++ b/src/photos-persistence/src/main/java/engineering/everest/lhotse/photos/persistence/PersistablePhoto.java
@@ -19,11 +19,11 @@ public class PersistablePhoto {
     @Id
     private UUID id;
     private UUID ownerUserId;
-    private UUID backingFileId;
+    private UUID persistedFileId;
     private String filename;
     private Instant uploadTimestamp;
 
     public Photo toDomain() {
-        return new Photo(id, ownerUserId, backingFileId, filename, uploadTimestamp);
+        return new Photo(id, ownerUserId, persistedFileId, filename, uploadTimestamp);
     }
 }

--- a/src/photos-persistence/src/main/java/engineering/everest/lhotse/photos/persistence/PhotosRepository.java
+++ b/src/photos-persistence/src/main/java/engineering/everest/lhotse/photos/persistence/PhotosRepository.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 @Repository
 public interface PhotosRepository extends JpaRepository<PersistablePhoto, UUID> {
 
-    default void createPhoto(UUID id, UUID ownerUserId, UUID backingFileId, String filename, Instant uploadTimestamp) {
-        save(new PersistablePhoto(id, ownerUserId, backingFileId, filename, uploadTimestamp));
+    default void createPhoto(UUID id, UUID ownerUserId, UUID persistedFileId, String filename, Instant uploadTimestamp) {
+        save(new PersistablePhoto(id, ownerUserId, persistedFileId, filename, uploadTimestamp));
     }
 
     List<PersistablePhoto> findByOwnerUserId(UUID ownerId, Pageable pageable);

--- a/src/photos-persistence/src/main/java/engineering/everest/lhotse/photos/services/DefaultPhotosReadService.java
+++ b/src/photos-persistence/src/main/java/engineering/everest/lhotse/photos/services/DefaultPhotosReadService.java
@@ -41,12 +41,12 @@ public class DefaultPhotosReadService implements PhotosReadService {
     @Override
     public InputStream streamPhoto(UUID requestingUserId, UUID photoId) throws IOException {
         var persistablePhoto = photosRepository.findByIdAndOwnerUserId(photoId, requestingUserId).orElseThrow();
-        return fileService.stream(persistablePhoto.getBackingFileId()).getInputStream();
+        return fileService.stream(persistablePhoto.getPersistedFileId()).getInputStream();
     }
 
     @Override
     public InputStream streamPhotoThumbnail(UUID requestingUserId, UUID photoId, int width, int height) throws IOException {
         var persistablePhoto = photosRepository.findByIdAndOwnerUserId(photoId, requestingUserId).orElseThrow();
-        return thumbnailService.streamThumbnailForOriginalFile(persistablePhoto.getBackingFileId(), width, height);
+        return thumbnailService.streamThumbnailForOriginalFile(persistablePhoto.getPersistedFileId(), width, height);
     }
 }

--- a/src/photos/src/main/java/engineering/everest/lhotse/photos/domain/PhotoAggregate.java
+++ b/src/photos/src/main/java/engineering/everest/lhotse/photos/domain/PhotoAggregate.java
@@ -24,27 +24,27 @@ public class PhotoAggregate implements Serializable {
 
     @AggregateIdentifier
     private UUID photoId;
-    private UUID backingFileId;
+    private UUID persistedFileId;
     private UUID ownerUserId;
 
     PhotoAggregate() {}
 
     @CommandHandler
     PhotoAggregate(RegisterUploadedPhotoCommand command) {
-        apply(new PhotoUploadedEvent(command.getPhotoId(), command.getOwningUserId(), command.getBackingFileId(), command.getFilename()));
+        apply(new PhotoUploadedEvent(command.getPhotoId(), command.getOwningUserId(), command.getPersistedFileId(), command.getFilename()));
     }
 
     @CommandHandler
     void handle(DeletePhotoForDeletedUserCommand command) {
         validatePhotoBelongsToDeletedUser(command);
 
-        apply(new PhotoDeletedAsPartOfUserDeletionEvent(photoId, backingFileId, command.getDeletedUserId()));
+        apply(new PhotoDeletedAsPartOfUserDeletionEvent(photoId, persistedFileId, command.getDeletedUserId()));
     }
 
     @EventSourcingHandler
     void on(PhotoUploadedEvent event) {
         photoId = event.getPhotoId();
-        backingFileId = event.getBackingFileId();
+        persistedFileId = event.getPersistedFileId();
         ownerUserId = event.getOwningUserId();
     }
 

--- a/src/photos/src/main/java/engineering/everest/lhotse/photos/domain/events/PhotoDeletedAsPartOfUserDeletionEvent.java
+++ b/src/photos/src/main/java/engineering/everest/lhotse/photos/domain/events/PhotoDeletedAsPartOfUserDeletionEvent.java
@@ -13,6 +13,6 @@ import java.util.UUID;
 @Revision("0")
 public class PhotoDeletedAsPartOfUserDeletionEvent {
     private UUID photoId;
-    private UUID backingFileId;
+    private UUID persistedFileId;
     private UUID deletedUserId;
 }

--- a/src/photos/src/main/java/engineering/everest/lhotse/photos/domain/events/PhotoUploadedEvent.java
+++ b/src/photos/src/main/java/engineering/everest/lhotse/photos/domain/events/PhotoUploadedEvent.java
@@ -17,7 +17,7 @@ public class PhotoUploadedEvent {
     private UUID photoId;
     @EncryptionKeyIdentifier
     private UUID owningUserId;
-    private UUID backingFileId;
+    private UUID persistedFileId;
     @EncryptedField
     private String filename;
 }

--- a/src/photos/src/main/java/engineering/everest/lhotse/photos/handlers/PhotosEventHandler.java
+++ b/src/photos/src/main/java/engineering/everest/lhotse/photos/handlers/PhotosEventHandler.java
@@ -32,16 +32,16 @@ public class PhotosEventHandler {
 
     @EventHandler
     void on(PhotoUploadedEvent event, @Timestamp Instant uploadTimestamp) {
-        LOGGER.info("User {} uploaded photo {} (backing file {})", event.getOwningUserId(), event.getPhotoId(), event.getBackingFileId());
-        photosRepository.createPhoto(event.getPhotoId(), event.getOwningUserId(), event.getBackingFileId(), event.getFilename(),
+        LOGGER.info("User {} uploaded photo {} (backing file {})", event.getOwningUserId(), event.getPhotoId(), event.getPersistedFileId());
+        photosRepository.createPhoto(event.getPhotoId(), event.getOwningUserId(), event.getPersistedFileId(), event.getFilename(),
             uploadTimestamp);
     }
 
     @EventHandler
     void on(PhotoDeletedAsPartOfUserDeletionEvent event) {
-        LOGGER.info("Deleting photo {} (backing file {}) for deleted user {}", event.getPhotoId(), event.getBackingFileId(),
+        LOGGER.info("Deleting photo {} (backing file {}) for deleted user {}", event.getPhotoId(), event.getPersistedFileId(),
             event.getDeletedUserId());
-        fileService.markEphemeralFileForDeletion(event.getBackingFileId());
+        fileService.markEphemeralFileForDeletion(event.getPersistedFileId());
         photosRepository.deleteById(event.getPhotoId());
     }
 }

--- a/src/photos/src/main/java/engineering/everest/lhotse/photos/services/DefaultPhotosService.java
+++ b/src/photos/src/main/java/engineering/everest/lhotse/photos/services/DefaultPhotosService.java
@@ -19,9 +19,9 @@ public class DefaultPhotosService implements PhotosService {
     }
 
     @Override
-    public UUID registerUploadedPhoto(UUID requestingUserId, UUID backingFileId, String filename) {
+    public UUID registerUploadedPhoto(UUID requestingUserId, UUID persistedFileId, String filename) {
         var photoId = randomFieldsGenerator.genRandomUUID();
-        commandGateway.sendAndWait(new RegisterUploadedPhotoCommand(photoId, requestingUserId, backingFileId, filename));
+        commandGateway.sendAndWait(new RegisterUploadedPhotoCommand(photoId, requestingUserId, persistedFileId, filename));
         return photoId;
     }
 }


### PR DESCRIPTION
## Proposed changes

The return value of `transferToStore` is the persisted file id but we are calling it backingFileId in the code. 
Renaming it to avoid confusion.

### Context
**backingStoreFileId:**  Id of the file in the backing store(Eg: S3/In-memory)
**persistedFileId:** Id of the uploaded file in the database
The relationship between these two is maintained in the **fileMappings** table.
